### PR TITLE
Fix deprecation warning in express 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function (app, db) {
 
           if (!opts.skipHeaders) res.set('Retry-After', after)
 
-          res.send(429, 'Rate limit exceeded')
+          res.status(429).send('Rate limit exceeded')
         })
 
       })


### PR DESCRIPTION
fixes deprecation warning:

```
express deprecated res.send(status, body): Use res.status(status).send(body) instead node_modules/express-limiter/index.js:43:15
```
