### PR TITLE
Allow for optional handler for rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ limiter(options)
  - `whitelist`: `function(req)` optional param allowing the ability to whitelist. return `boolean`, `true` to whitelist, `false` to passthru to limiter.
  - `skipHeaders`: `Boolean` whether to skip sending HTTP headers for rate limits ()
  - `ignoreErrors`: `Boolean` whether errors generated from redis should allow the middleware to call next().  Defaults to false.
+ - `onRateLimited`: `Function` called when a request exceeds the configured rate limit.
 
 ### Examples
 
@@ -101,6 +102,16 @@ limiter({
     return !!req.user.is_admin
   },
   skipHeaders: true
+})
+
+// call a custom limit handler
+limiter({
+  path: '*',
+  method: 'all',
+  lookup: 'connection.remoteAddress',
+  onRateLimited: function (req, res, next) {
+    next({ message: 'Rate limit exceeded', status: 429 })
+  }
 })
 
 ```

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ module.exports = function (app, db) {
     var middleware = function (req, res, next) {
       if (opts.whitelist && opts.whitelist(req)) return next()
       opts.lookup = Array.isArray(opts.lookup) ? opts.lookup : [opts.lookup]
-
+      opts.onRateLimited = typeof opts.onRateLimited === 'function' ? opts.onRateLimited : function (req, res, next) {
+        res.status(429).send('Rate limit exceeded')
+      }
       var lookups = opts.lookup.map(function (item) {
         return item + ':' + item.split('.').reduce(function (prev, cur) {
           return prev[cur]
@@ -40,7 +42,7 @@ module.exports = function (app, db) {
 
           if (!opts.skipHeaders) res.set('Retry-After', after)
 
-          res.status(429).send('Rate limit exceeded')
+          opts.onRateLimited(req, res, next)
         })
 
       })


### PR DESCRIPTION
Instead of hardcoding a response, allow an application to define its own way of handling rate limits being hit.