### PR TITLE
Option to log traffic before setting limits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ limiter(options)
  - `whitelist`: `function(req)` optional param allowing the ability to whitelist. return `boolean`, `true` to whitelist, `false` to passthru to limiter.
  - `skipHeaders`: `Boolean` whether to skip sending HTTP headers for rate limits ()
  - `ignoreErrors`: `Boolean` whether errors generated from redis should allow the middleware to call next().  Defaults to false.
-  - `log`: `Boolean` whether to log or throttle requests above the limit, handy when you want to understand your traffic before limiting.  Defaults to false.
+ - `log`: `Boolean` whether to log the limmiter behaiviour, handy when you want to understand understand why the throttle triggered when you have continous changes on your traffic.  Defaults to false.
+ - `logOnly`: `Boolean` whether to log or throttle requests above the limit, handy when you want to understand your traffic before limiting.  Defaults to false.
+
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ limiter(options)
 ```
 
  - `path`: `String` *optional* route path to the request
- - `method`: `String` *optional* http method. accepts `get`, `post`, `put`, `delete`, and of course Express' `all`
+ - `method`: `String` not really *optional* http method. accepts `get`, `post`, `put`, `delete`, and of course Express' `all`. If you want to log each type, you better do `req.method.toLowerCase()`
  - `lookup`: `String|Array.<String>` value lookup on the request object. Can be a single value or array. See [examples](#examples) for common usages
  - `total`: `Number` allowed number of requests before getting rate limited
  - `expire`: `Number` amount of time in `ms` before the rate-limited is reset

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ limiter(options)
 ```
 
  - `path`: `String` *optional* route path to the request
+ - `request`: `String` *optional* actual request `req.path`
  - `method`: `String` not really *optional* http method. accepts `get`, `post`, `put`, `delete`, and of course Express' `all`. If you want to log each type, you better do `req.method.toLowerCase()`
  - `lookup`: `String|Array.<String>` value lookup on the request object. Can be a single value or array. See [examples](#examples) for common usages
  - `total`: `Number` allowed number of requests before getting rate limited

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ limiter({
   expire: 1000 * 60 * 60
 })
 
+/**
+* You can also set log to true and use a callback to handle that data.
+* This is handy for cases in which you want to understand what's your traffic like, before setting any limit.
+*/
+
+limiter({
+  path: '/api/action',
+  method: 'get',
+  lookup: ['connection.remoteAddress'],
+  // 150 requests per hour
+  total: 150,
+  expire: 1000 * 60 * 60,
+  // By default log is set to false
+  log: true
+}, function (data){
+  console.log(data)
+})
+
 app.get('/api/action', function (req, res) {
   res.send(200, 'ok')
 })
@@ -47,6 +65,7 @@ limiter(options)
  - `whitelist`: `function(req)` optional param allowing the ability to whitelist. return `boolean`, `true` to whitelist, `false` to passthru to limiter.
  - `skipHeaders`: `Boolean` whether to skip sending HTTP headers for rate limits ()
  - `ignoreErrors`: `Boolean` whether errors generated from redis should allow the middleware to call next().  Defaults to false.
+  - `log`: `Boolean` whether to log or throttle requests above the limit, handy when you want to understand your traffic before limiting.  Defaults to false.
 
 ### Examples
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function (app, db) {
       opts.lookup = Array.isArray(opts.lookup) ? opts.lookup : [opts.lookup]
 
       var lookups = opts.lookup.map(function (item) {
-        return item + ':' + item.split('.').reduce(function (prev, cur) {
+        return !Array.isArray(item) ? item : item + ':' + item.split('.').reduce(function (prev, cur) {
           return prev[cur]
         }, req)
       }).join(':')

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 module.exports = function (app, db) {
   return function (opts, callback) {
     var middleware = function (req, res, next) {
-      if (opts.log) {
+      if (opts.log !== false) {
         var logData = 'Path: '+opts.path+', Method: '+req.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
         callback(logData);
       }
-      if (opts.logOnly) {
+      if (opts.logOnly !== false) {
         return next();
       }
       if (opts.whitelist && opts.whitelist(req)) return next()

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 module.exports = function (app, db) {
   return function (opts, callback) {
     var middleware = function (req, res, next) {
+      if (opts.log) {
+        var logData = 'Path: '+opts.path+', Method: '+opts.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
+        callback(logData);
+        return next();
+      }
       if (opts.whitelist && opts.whitelist(req)) return next()
       opts.lookup = Array.isArray(opts.lookup) ? opts.lookup : [opts.lookup]
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = function (app, db) {
       if (opts.log) {
         var logData = 'Path: '+opts.path+', Method: '+opts.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
         callback(logData);
+      }
+      if (opts.logOnly) {
         return next();
       }
       if (opts.whitelist && opts.whitelist(req)) return next()

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function (app, db) {
   return function (opts, callback) {
     var middleware = function (req, res, next) {
       if (opts.log !== false) {
-        var logData = 'Path: '+opts.path+', Method: '+req.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
+        var logData = 'Path: '+opts.request+', Method: '+opts.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
         callback(logData);
       }
       if (opts.logOnly !== false) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function (app, db) {
   return function (opts, callback) {
     var middleware = function (req, res, next) {
       if (opts.log) {
-        var logData = 'Path: '+opts.path+', Method: '+opts.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
+        var logData = 'Path: '+opts.path+', Method: '+req.method+', Lookup: '+opts.lookup+', Total: '+opts.total+', Expire: '+opts.expire;
         callback(logData);
       }
       if (opts.logOnly) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function (app, db) {
-  return function (opts) {
+  return function (opts, callback) {
     var middleware = function (req, res, next) {
       if (opts.whitelist && opts.whitelist(req)) return next()
       opts.lookup = Array.isArray(opts.lookup) ? opts.lookup : [opts.lookup]

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ded/express-limiter.git"
+    "url": "git://github.com/jgtoriginal/express-limiter.git"
   },
   "bugs": {
-    "url": "https://github.com/ded/express-limiter/issues"
+    "url": "https://github.com/jgtoriginal/express-limiter/issues"
   },
-  "homepage": "https://github.com/ded/express-limiter",
+  "homepage": "https://github.com/jgtoriginal/express-limiter",
   "devDependencies": {
     "express": "4.0.0",
     "redis": "~0.10.1",


### PR DESCRIPTION
So far express-limiter gives you the option to limit your traffic.
With this PR I'm bringing the option of logging traffic in stead of limiting it.
It works all the same way, except that if you set 'log' to 'true' in stead of limiting the traffic, you will get data telling you that the limit was hit, and you can handle that data as you better think of.
In my case I'm writing a log file, but here I just let you guys a console.log example.
Thx!
