### PR TITLE
If "X-RateLimit-Remaining: 1", allow one additional API request

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,15 +29,15 @@ module.exports = function (app, db) {
         }
 
         // do not allow negative remaining
-        limit.remaining = Math.max(Number(limit.remaining) - 1, 0)
+        limit.remaining = Math.max(Number(limit.remaining) - 1, -1)
         db.set(key, JSON.stringify(limit), 'PX', opts.expire, function (e) {
           if (!opts.skipHeaders) {
             res.set('X-RateLimit-Limit', limit.total)
-            res.set('X-RateLimit-Remaining', limit.remaining)
             res.set('X-RateLimit-Reset', Math.ceil(limit.reset / 1000)) // UTC epoch seconds
+            res.set('X-RateLimit-Remaining', Math.max(limit.remaining,0))
           }
 
-          if (limit.remaining) return next()
+          if (limit.remaining >= 0) return next()
 
           var after = (limit.reset - Date.now()) / 1000
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -21,7 +21,7 @@ describe('rate-limiter', function () {
   })
 
   it('should work', function (done) {
-    var map = [10, 9, 8, 7, 6, 5, 4, 3, 2]
+    var map = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     var clock = sinon.useFakeTimers()
 
     limiter({


### PR DESCRIPTION
In the current version of this middleware, when the header `X-RateLimit-Remaining` is set to 1, the next API call will actually result in a `429 Rate Limit Exceeded`.  The current unit tests verify that if the rate limit is set to `10`, then `9` API requests can be made.  If the unit test is changed to test for a full `10` requests against a limit of `10, the test will fail.

This PR allows for the middleware to provide the correct number of requests based on the configured limit.  If the limit is set to 10, then 10 requests can be made before the `429` response.