### PR TITLE
Adds ability to set a custom header prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,10 @@ module.exports = function (app, db) {
         limit.remaining = Math.max(Number(limit.remaining) - 1, -1)
         db.set(key, JSON.stringify(limit), 'PX', opts.expire, function (e) {
           if (!opts.skipHeaders) {
-            res.set('X-RateLimit-Limit', limit.total)
-            res.set('X-RateLimit-Reset', Math.ceil(limit.reset / 1000)) // UTC epoch seconds
-            res.set('X-RateLimit-Remaining', Math.max(limit.remaining,0))
+            var prefix = opts.prefix || 'X-'
+            res.set(prefix + 'RateLimit-Limit', limit.total)
+            res.set(prefix + 'RateLimit-Reset', Math.ceil(limit.reset / 1000)) // UTC epoch seconds
+            res.set(prefix + 'RateLimit-Remaining', Math.max(limit.remaining,0))
           }
 
           if (limit.remaining >= 0) return next()

--- a/tests/index.js
+++ b/tests/index.js
@@ -102,6 +102,45 @@ describe('rate-limiter', function () {
           .expect(429, done)
     })
 
+    it('should process options.prefix', function (done) {
+      limiter({
+        path: '/route',
+        method: 'get',
+        lookup: ['connection.remoteAddress'],
+        total: 0,
+        expire: 1000 * 60 * 60,
+        prefix: 'Test-'
+      })
+
+      app.get('/route', function (req, res) {
+        res.send(200, 'hello')
+      })
+
+      request(app)
+        .get('/route')
+          .expect(function(res) {
+            if ('X-RateLimit-Limit'.toLowerCase() in res.headers) {
+              return 'X-RateLimit-Limit Header not to be set'
+            }
+          })
+          .expect(function(res) {
+            if ('X-RateLimit-Remaining'.toLowerCase() in res.headers) {
+              return 'X-RateLimit-Remaining Header not to be set'
+            }
+          })
+          .expect(function(res) {
+            if ('Test-RateLimit-Limit'.toLowerCase() in res.headers === false) {
+              return 'Test-RateLimit-Limit Header (custom prefix) to be set'
+            }
+          })
+          .expect(function(res) {
+            if ('Test-RateLimit-Remaining'.toLowerCase() in res.headers === false) {
+              return 'Test-RateLimit-Remaining Header (custom prefix) to be set'
+            }
+          })
+          .expect(429, done)
+    })
+
     it('should process ignoreErrors', function (done) {
       limiter({
         path: '/route',


### PR DESCRIPTION
Hi!

I'm dealing with a bit of an exotic use case.  I'm using express-limiter on a proxy sever and need a consumer to be able to differentiate between rate limit being imposed by my proxy, or an upstream rate limit by the service I'm proxying.

The upstream service passes the 'X-RateLimit-Limit' header one would expect, I want to be able to set a different header ex: 'DR-RateLimit-Limit' that doesn't conflict with the proxied service.

If you feel this isn't a practical enough use case, feel free to decline.