### PR TITLE
Allows it to work with undefined lookups

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (app, db) {
       }
       var lookups = opts.lookup.map(function (item) {
         return item + ':' + item.split('.').reduce(function (prev, cur) {
-          return prev[cur]
+          return prev ? prev[cur] : undefined
         }, req)
       }).join(':')
       var path = opts.path || req.path

--- a/tests/index.js
+++ b/tests/index.js
@@ -153,6 +153,25 @@ describe('rate-limiter', function () {
         done(e)
       })
     })
+
+    it('should work with undefined lookups', function (done) {
+      limiter({
+        path: '/route',
+        method: 'get',
+        lookup: ['doesNotExist.remoteAddress', 'connection.doesNotExist'],
+        total: 0,
+        expire: 1000 * 60 * 60,
+        skipHeaders: true
+      })
+
+      app.get('/route', function (req, res) {
+        res.send(200, 'hello')
+      })
+
+      request(app)
+        .get('/route')
+        .expect(429, done)
+    })
   })
 
   context('direct middleware', function () {


### PR DESCRIPTION
When I tried to use `jwtPayload.email` I got a `TypeError: Cannot read property 'email' of undefined` because I was using an unauthenticated method, so I fixed that.